### PR TITLE
Revdeps: Avoid testing several times the same packages

### DIFF
--- a/src/opam_ops.ml
+++ b/src/opam_ops.ml
@@ -75,13 +75,19 @@ module V1 = struct
     Term.return r
 
   let run_revdeps ?volume ({run_t;_} as t) packages image =
-    List.map (fun pkg ->
-      let terms =
-        list_revdeps t image pkg >>=
-        run_packages ?volume run_t image in
-      let l = Fmt.strf "revdeps:%s" pkg in
-      l, terms) packages |>
-    Term.wait_for_all
+    let l = Fmt.strf "revdeps:%s" (String.concat ~sep:", " packages) in
+    let terms =
+      List.fold_left
+        (fun acc pkg ->
+           acc >>= fun acc ->
+           list_revdeps t image pkg >|= fun pkgs ->
+           String.Set.union (String.Set.of_list pkgs) acc)
+        (Term.return String.Set.empty)
+        packages >|=
+      String.Set.elements >>=
+      run_packages ?volume run_t image
+    in
+    Term.wait_for_all [(l, terms)]
 
 end
 
@@ -143,13 +149,19 @@ module V2 = struct
     List.map (fun s -> String.trim s)
 
   let run_revdeps ?volume ({run_t;_} as t) packages image =
-    List.map (fun pkg ->
-      let terms =
-        list_revdeps t image pkg >>=
-        run_packages ?volume run_t image in
-      let l = Fmt.strf "revdeps:%s" pkg in
-      l, terms) packages |>
-    Term.wait_for_all
+    let l = Fmt.strf "revdeps:%s" (String.concat ~sep:", " packages) in
+    let terms =
+      List.fold_left
+        (fun acc pkg ->
+           acc >>= fun acc ->
+           list_revdeps t image pkg >|= fun pkgs ->
+           String.Set.union (String.Set.of_list pkgs) acc)
+        (Term.return String.Set.empty)
+        packages >|=
+      String.Set.elements >>=
+      run_packages ?volume run_t image
+    in
+    Term.wait_for_all [(l, terms)]
 
 end
 


### PR DESCRIPTION
The OPAM CI is currently struggling in building loads of reverse dependencies for janestreet's release**s**: https://github.com/ocaml/opam-repository/pull/11009

This PR should avoid this in the future by avoiding the build of packages that has been already built. This can happen in case several of the packages being tested have the same reverse dependencies.

NOTE: Do not use this right away as this has not been tested.