### PR TITLE
Don't ignore revdeps failures

### DIFF
--- a/src/opam_ops.ml
+++ b/src/opam_ops.ml
@@ -71,8 +71,7 @@ module V1 = struct
       let t, branch = run_package ?volume t image pkg in
       pkg, t, branch
     ) pkgs |> fun r ->
-    Term.wait_for_all (List.map (fun (a,b,_) -> (a,b)) r) |>
-    Term_utils.ignore_failure ~on_fail:(fun _ -> ()) >>= fun () ->
+    Term.wait_for_all (List.map (fun (a,b,_) -> (a,b)) r) >>= fun () ->
     Term.return r
 
   let run_revdeps ?volume ({run_t;_} as t) packages image =
@@ -133,8 +132,7 @@ module V2 = struct
       let t, branch = run_package ?volume t image pkg in
       pkg, t, branch
     ) pkgs |> fun r ->
-    Term.wait_for_all (List.map (fun (a,b,_) -> (a,b)) r) |>
-    Term_utils.ignore_failure ~on_fail:(fun _ -> ()) >>= fun () ->
+    Term.wait_for_all (List.map (fun (a,b,_) -> (a,b)) r) >>= fun () ->
     Term.return r
 
   let list_all_packages {run_t} image =


### PR DESCRIPTION
This should avoid having a green tick when a reverse dependency has failed.
(again this hasn't been tested)

The two modified functions are also used by the ```bulk_build``` function and I'm not sure what it does but I'm proposing anyway just in case.