### PR TITLE
Merge PRs into master instead of testing them in their own branch

### DIFF
--- a/src/opam_build.ml
+++ b/src/opam_build.ml
@@ -107,8 +107,8 @@ module Opam_builder = struct
               OD.clone_src ~user ~repo ~branch ~commit @@
               OD.add_local_pins packages
           | `Full_repo ->
-              OD.clone_src ~user ~repo ~branch ~commit @@
-              OD.switch_local_remote
+              OD.set_opam_repo_rev ~remote:opam_repo_remote opam_repo_rev @@
+              OD.merge_src ~user ~repo ~branch ~commit
           | `Repo ->
               OD.set_opam_repo_rev ~remote:opam_repo_remote opam_repo_rev @@
               OD.clone_src ~user ~repo ~branch ~commit @@

--- a/src/opam_build.ml
+++ b/src/opam_build.ml
@@ -23,27 +23,7 @@ type key = {
 }
 
 module Opam_key = struct
-
   type t = key
-
-  let compare_target a b =
-    match a,b with
-    |Some a, Some b -> Target.compare_v a b
-    |_ -> Pervasives.compare a b
-
-  let ( ++ ) x fn =
-    match x with
-    | 0 -> fn ()
-    | r -> r
-
-  let compare {packages;target;distro;ocaml_version;remotes;typ;opam_version} b =
-    Pervasives.compare packages b.packages ++ fun () ->
-    compare_target target b.target ++ fun () ->
-    String.compare distro b.distro ++ fun () ->
-    String.compare ocaml_version b.ocaml_version ++ fun () ->
-    Pervasives.compare typ b.typ ++ fun () ->
-    Pervasives.compare opam_version b.opam_version ++ fun () ->
-    Pervasives.compare remotes b.remotes
 end
 
 module Opam_builder = struct

--- a/src/opam_build.ml
+++ b/src/opam_build.ml
@@ -119,7 +119,7 @@ module Opam_builder = struct
       |`Ref rl -> Ref.pp ppf rl
     in
     let target = Fmt.(strf "%a" (option target_v_pp) target) in
-    let remotes = Fmt.(strf "%a" (list Remote.pp) remotes) in
+    let remotes = Fmt.(strf "%a" (list Remote.pp_for_compare) remotes) in
     let packages = String.concat ~sep:" " packages in
     let opam_version = match opam_version with `V1 -> "v1" | `V2 -> "v2" in
     let typ = match typ with `Package -> "package" |`Repo -> "repo" |`Full_repo -> "fullrepo" in

--- a/src/opam_docker.ml
+++ b/src/opam_docker.ml
@@ -15,9 +15,9 @@ module Remote = struct
     full_remote: bool;
   }
 
-  let pp ppf {repo; commit; full_remote } =
-    Fmt.pf ppf "repo=%a commit=%a full_remote=%b"
-      Repo.pp repo Commit.pp commit full_remote
+  let pp_for_compare ppf {repo; commit = _; full_remote } =
+    Fmt.pf ppf "repo=%a full_remote=%b"
+      Repo.pp repo full_remote
 end
 
 let repo ~user ~repo ~branch =

--- a/src/opam_docker.ml
+++ b/src/opam_docker.ml
@@ -15,16 +15,6 @@ module Remote = struct
     full_remote: bool;
   }
 
-  let ( ++ ) x fn =
-    match x with
-    | 0 -> fn ()
-    | r -> r
-
-  let compare {repo; commit; full_remote} b =
-    Repo.compare repo b.repo ++ fun () ->
-    Commit.compare commit b.commit ++ fun () ->
-    Pervasives.compare full_remote b.full_remote
-
   let pp ppf {repo; commit; full_remote } =
     Fmt.pf ppf "repo=%a commit=%a full_remote=%b"
       Repo.pp repo Commit.pp commit full_remote

--- a/src/opam_docker.mli
+++ b/src/opam_docker.mli
@@ -28,6 +28,7 @@ module type V = sig
   val set_opam_repo_rev : ?remote:Remote.t -> ?branch:string -> ?dst_branch:string -> string -> Dockerfile.t
   val base : ocaml_version:string -> distro:string -> Dockerfile.t
   val clone_src : user:string -> repo:string -> branch:string -> commit:string -> Dockerfile.t
+  val merge_src : user:string -> repo:string -> branch:string -> commit:string -> Dockerfile.t
   val add_local_pins : string list -> Dockerfile.t
   val switch_local_remote : Dockerfile.t
   val add_local_remote : Dockerfile.t

--- a/src/opam_docker.mli
+++ b/src/opam_docker.mli
@@ -13,7 +13,7 @@ module Remote : sig
     commit: Commit.t;
     full_remote: bool;
   }
-  val pp : t Fmt.t
+  val pp_for_compare : t Fmt.t
 end
 
 val repo : user:string -> repo:string -> branch:string -> Repo.t * string

--- a/src/opam_docker.mli
+++ b/src/opam_docker.mli
@@ -13,7 +13,6 @@ module Remote : sig
     commit: Commit.t;
     full_remote: bool;
   }
-  val compare : t -> t -> int
   val pp : t Fmt.t
 end
 


### PR DESCRIPTION
Test PR changes and fixes the way PRs are tested. The current behaviour is to make the tested branch the new default opam remote but this is totally wrong if the branch is old or comes from an old master branch: some packages will be not present/out-of-date.

For example of such case, see: https://github.com/ocaml/opam-repository/pull/11259

Tested live on https://arm64.ci.ocamllabs.io/jpdeplaix/opam-repository/pr/8