### PR TITLE
Test all revdeps versions

### DIFF
--- a/src/opam_ops.ml
+++ b/src/opam_ops.ml
@@ -136,7 +136,7 @@ module V2 = struct
     List.map (fun s -> String.trim s)
 
   let list_revdeps {run_t;_} image pkg =
-    let cmd = ["opam";"list";"-s";"--color=never";"--depends-on";pkg;"--installable"] in
+    let cmd = ["opam";"list";"-s";"--color=never";"--depends-on";pkg;"--installable"; "--all-versions"] in
     Docker_run.run ~tag:image.Docker_build.sha256 ~cmd run_t >|=
     String.cuts ~empty:false ~sep:"\n" >|=
     List.map (fun s -> String.trim s)


### PR DESCRIPTION
This PR allows the revdeps check to test every versions of the dependencies separately.
This is obviously an improvement compared to testing only the latest version (some dependencies might have changed their dependencies for example).

EDIT: I would advice to merge #11 first as it would dramatically increase the load of the CI otherwise.

Tested live on https://arm64.ci.ocamllabs.io