### PR TITLE
Enable to test opam-depext new releases if needed

### DIFF
--- a/src/opam_docker.ml
+++ b/src/opam_docker.ml
@@ -157,8 +157,7 @@ module V2 = struct
   let base ~ocaml_version ~distro =
     from ~tag:(distro^"-ocaml-" ^ ocaml_version) "ocaml/opam2" @@
     add_cache_dir @@
-    run "opam pin add -y opam-depext https://github.com/ocaml/opam-depext.git#2.0" @@
-    run "opam reinstall -yv opam-depext"
+    run "opam install -yv opam-depext"
 
   let add_archive_script =
     generate_sh "opam-ci-archive" [


### PR DESCRIPTION
In case ```opam-depext``` is released or fixed by a PR, none of the CIs can test if it actually compiles because it is either already pinned locally or opam1 is used.
Example of such event: https://github.com/ocaml/opam-repository/pull/11318

This PR just removes the pin to the dev version as it is no longer needed I believe.

Tested live on https://arm64.ci.ocamllabs.io/jpdeplaix/opam-repository/pr/9

cc @AltGr