### PR TITLE
Fix and remove the opam-diff image

### DIFF
--- a/Dockerfile.opam-diff
+++ b/Dockerfile.opam-diff
@@ -1,4 +1,0 @@
-FROM alpine
-RUN apk --no-cache add curl
-COPY scripts/opam-github-pr-diff /root/opam-github-pr-diff
-ENTRYPOINT ["/root/opam-github-pr-diff"]

--- a/scripts/opam-github-pr-diff
+++ b/scripts/opam-github-pr-diff
@@ -1,8 +1,0 @@
-#!/bin/sh -eu
-
-REPO_SLUG=$1
-PRNUM=$2
-
-curl -sL https://github.com/$REPO_SLUG/pull/$PRNUM.diff | \
-  sed -E -n -e 's,\+\+\+ b/packages/[^/]*/([^/]*)/.*,\1,p' | \
-  sort -u


### PR DESCRIPTION
The rationals for this PR are:
* The opam-diff image has to be rebuilt for every architectures and it's painful.
* Once ran, the image used will be the one in the docker cache and if the PR adds or modifies other packages this changes will not be tested
* If the build step is rebuilt (anybody can do it on the CI), every single PRs will be rebuilt as well due to the fact that the image was the same for each one.