### PR TITLE
Avoid downgrading the checked package when testing its revdeps

### DIFF
--- a/src/opam_ops.ml
+++ b/src/opam_ops.ml
@@ -166,9 +166,14 @@ module V2 = struct
 end
 
 let build_package {build_t;_} image pkg =
+  let base_pkg, version_pkg = match String.cut ~sep:"." pkg with
+    | None -> failwith ("Couldn't extract the version number from "^pkg)
+    | Some x -> x
+  in
   let open !Dockerfile in
   let dfile =
     from image.Docker_build.sha256 @@
+    run "opam pin add -k version -yn %s %s" base_pkg version_pkg @@
     run "opam config exec -- opam-ci-install %s" pkg in
   let hum = Fmt.strf "opam install %s" pkg in
   Docker_build.run build_t ~hum dfile


### PR DESCRIPTION
I believe it's always a sensible thing to do and it's a nice fix while waiting for https://github.com/ocaml/opam/issues/3229 to be fixed.

Currently running on the ARM64 CI.