### PR TITLE
Test Opam1 only once

### DIFF
--- a/src-bin/mirageCI.ml
+++ b/src-bin/mirageCI.ml
@@ -32,7 +32,7 @@ module Builder = struct
       |`Package -> packages_of_repo target
       |`Repo |`Full_repo -> Opam_ops.packages_from_diff docker_t target in
     let opam_repo = Opam_docker.mirage_opam_repository in
-    Opam_ops.run_phases ~revdeps ~packages ~remotes ~typ ~opam_version ~opam_repo opam_t docker_t target
+    Opam_ops.run_phases ~mode:(`Revdeps revdeps) ~packages ~remotes ~typ ~opam_version ~opam_repo opam_t docker_t target
 
   let run_phases typ remotes target =
     let all_tests = repo_builder ~opam_version:`V1 ~typ ~remotes target in
@@ -85,4 +85,3 @@ let () =
    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
   ---------------------------------------------------------------------------*)
-

--- a/src-bin/opamRepoCI.ml
+++ b/src-bin/opamRepoCI.ml
@@ -17,15 +17,15 @@ module Builder = struct
   let volume_v1 = Fpath.v "opam-archive"
   let volume_v2 = Fpath.v "opam2-archive"
 
-  let repo_builder ~revdeps ~typ ~opam_version ?volume target =
+  let repo_builder ~mode ~typ ~opam_version ?volume target =
     let packages = Opam_ops.packages_from_diff ~default:[] docker_t target in
     let opam_repo = Opam_docker.ocaml_opam_repository in
-    Opam_ops.run_phases ?volume ~revdeps ~packages ~remotes:[] ~typ ~opam_version ~opam_repo opam_t docker_t target
+    Opam_ops.run_phases ?volume ~mode ~packages ~remotes:[] ~typ ~opam_version ~opam_repo opam_t docker_t target
 
   let run_phases typ target =
     let tests ~revdeps =
-      (repo_builder ~revdeps:false ~typ ~opam_version:`V1 ~volume:volume_v1 target) @
-      (repo_builder ~revdeps ~typ ~opam_version:`V2 ~volume:volume_v2 target)
+      (repo_builder ~mode:`Build_only ~typ ~opam_version:`V1 ~volume:volume_v1 target) @
+      (repo_builder ~mode:(`Revdeps revdeps) ~typ ~opam_version:`V2 ~volume:volume_v2 target)
     in
     match Target.id target with
     |`Ref _  -> []
@@ -65,4 +65,3 @@ let () =
    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
   ---------------------------------------------------------------------------*)
-

--- a/src/opam_ops.mli
+++ b/src/opam_ops.mli
@@ -23,7 +23,7 @@ val distro_build :
 
 val run_phases :
   ?volume: Fpath.t ->
-  revdeps: bool ->
+  mode: [`Build_only | `Revdeps of bool] ->
   packages:string list Datakit_ci.Term.t ->
   remotes:(Datakit_github.Repo.t * string) list ->
   typ:[ `Package | `Repo | `Full_repo ] ->
@@ -63,4 +63,3 @@ module V2 : V
    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
   ---------------------------------------------------------------------------*)
-


### PR DESCRIPTION
cc @UnixJunkie that would be a trade-off between what we have today and an opam2 only CI.

Summary: this makes the CI just build only the first 4.05.0 build and not anything else in case of opam1 and everything as before in case of opam2. As discussed before with @avsm the opam1 build is still here in case the automatic translation between from opam1 to opam2 format become a bit funky and also to avoid errors when people want to merge to the 2.0.0 branch not knowing they should not (yet).