### PR TITLE
Use the new docker images

### DIFF
--- a/src/opam_build.ml
+++ b/src/opam_build.ml
@@ -15,7 +15,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 type key = {
   packages: string list; (* TODO merge this with Packages as only used there *)
   distro: string;
-  ocaml_version: string;
+  ocaml_version: Oversions.version;
   remotes: Remote.t list;
   target: Target.v option;
   typ: [`Package | `Repo | `Full_repo ];
@@ -54,7 +54,7 @@ module Opam_builder = struct
           (String.with_range ~len:8 (Commit.hash commit))
        ) remotes)
       in
-    Fmt.strf "Dockerfile %a %s/ocaml-%s/%s)" Fmt.(list ~sep:sp string) packages distro ocaml_version sremotes
+    Fmt.strf "Dockerfile %a %s/ocaml-%s/%s)" Fmt.(list ~sep:sp string) packages distro (Oversions.to_string ocaml_version) sremotes
 
   let generate _t ~switch:_ ~log trans NoContext {target;packages;distro;ocaml_version;remotes;typ;opam_version} =
     let (module OD:Opam_docker.V) =
@@ -105,7 +105,7 @@ module Opam_builder = struct
     let open Utils.Infix in
     let open Datakit_client.Path.Infix in
     let output = Live_log.write log in
-    Live_log.log log "Building Dockerfile for installing %a (%s %s)" (Fmt.(list ~sep:sp string)) packages distro ocaml_version;
+    Live_log.log log "Building Dockerfile for installing %a (%s %s)" (Fmt.(list ~sep:sp string)) packages distro (Oversions.to_string ocaml_version);
     let data = Dockerfile_conv.to_cstruct dockerfile in
     DK.Transaction.create_or_replace_file trans (Cache.Path.value / "Dockerfile.sexp") data >>*= fun () ->
     output (Dockerfile.string_of_t dockerfile ^ "\n");
@@ -123,7 +123,7 @@ module Opam_builder = struct
     let packages = String.concat ~sep:" " packages in
     let opam_version = match opam_version with `V1 -> "v1" | `V2 -> "v2" in
     let typ = match typ with `Package -> "package" |`Repo -> "repo" |`Full_repo -> "fullrepo" in
-    Fmt.strf "%s%s%s%s%s%s%s" target packages distro ocaml_version remotes opam_version typ |>
+    Fmt.strf "%s%s%s%s%s%s%s" target packages distro (Oversions.to_string_with_minor ocaml_version) remotes opam_version typ |>
     Digest.string |> Digest.to_hex |> Fmt.strf "opam-build-%s"
 
   let load _t tr _k =

--- a/src/opam_build.mli
+++ b/src/opam_build.mli
@@ -15,7 +15,7 @@ val v : logs:Live_log.manager -> label:string -> t
   Dockerfiles from {!key} parameters. *)
 
 val run : ?packages:string list -> ?target:Target.v -> distro:string ->
-  ocaml_version:string -> remotes:Opam_docker.Remote.t list -> typ:[`Package|`Repo|`Full_repo]
+  ocaml_version:Oversions.version -> remotes:Opam_docker.Remote.t list -> typ:[`Package|`Repo|`Full_repo]
   -> opam_version:[`V1|`V2] -> t -> Dockerfile.t Term.t
 (** [run t key] will result in a Datakit_ci {!Term.t} that will generate
   a {!Dockerfile.t} that can be built using a {!Docker_build.t} instance

--- a/src/opam_docker.ml
+++ b/src/opam_docker.ml
@@ -141,7 +141,7 @@ module V2 = struct
   let set_opam_repo_rev = V1.set_opam_repo_rev
 
   let base ~ocaml_version ~distro =
-    from ~tag:(distro^"-"^Oversions.docker_opam2 ocaml_version) "ocaml/opam2" @@
+    from ~tag:(distro^"-"^Oversions.docker_opam2 ocaml_version) "ocaml/opam2-staging" @@
     add_cache_dir @@
     run "opam install -yv opam-depext"
 

--- a/src/opam_docker.ml
+++ b/src/opam_docker.ml
@@ -30,7 +30,7 @@ module type V = sig
   val add_cache_dir : Dockerfile.t
   val add_remotes : Remote.t list -> Dockerfile.t
   val set_opam_repo_rev : ?remote:Remote.t -> ?branch:string -> ?dst_branch:string -> string -> Dockerfile.t
-  val base : ocaml_version:string -> distro:string -> Dockerfile.t
+  val base : ocaml_version:Oversions.version -> distro:string -> Dockerfile.t
   val clone_src : user:string -> repo:string -> branch:string -> commit:string -> Dockerfile.t
   val merge_src : user:string -> repo:string -> branch:string -> commit:string -> Dockerfile.t
   val add_local_pins : string list -> Dockerfile.t
@@ -69,7 +69,7 @@ module V1 = struct
     empty @@@ remotes
 
   let base ~ocaml_version ~distro =
-    from ~tag:(distro^"_ocaml-"^ocaml_version) "ocaml/opam"
+    from ~tag:(distro^"_"^Oversions.docker_opam1 ocaml_version) "ocaml/opam"
 
   let set_opam_repo_rev ?remote ?(branch="master") ?(dst_branch="cibranch") rev =
     workdir "/home/opam/opam-repository" @@
@@ -141,7 +141,7 @@ module V2 = struct
   let set_opam_repo_rev = V1.set_opam_repo_rev
 
   let base ~ocaml_version ~distro =
-    from ~tag:(distro^"-ocaml-" ^ ocaml_version) "ocaml/opam2" @@
+    from ~tag:(distro^"-"^Oversions.docker_opam2 ocaml_version) "ocaml/opam2" @@
     add_cache_dir @@
     run "opam install -yv opam-depext"
 
@@ -167,4 +167,3 @@ end
    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
   ---------------------------------------------------------------------------*)
-

--- a/src/opam_docker.mli
+++ b/src/opam_docker.mli
@@ -24,7 +24,7 @@ module type V = sig
   val add_cache_dir : Dockerfile.t
   val add_remotes : Remote.t list -> Dockerfile.t
   val set_opam_repo_rev : ?remote:Remote.t -> ?branch:string -> ?dst_branch:string -> string -> Dockerfile.t
-  val base : ocaml_version:string -> distro:string -> Dockerfile.t
+  val base : ocaml_version:Oversions.version -> distro:string -> Dockerfile.t
   val clone_src : user:string -> repo:string -> branch:string -> commit:string -> Dockerfile.t
   val merge_src : user:string -> repo:string -> branch:string -> commit:string -> Dockerfile.t
   val add_local_pins : string list -> Dockerfile.t
@@ -52,4 +52,3 @@ module V2 : V
    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
   ---------------------------------------------------------------------------*)
-

--- a/src/opam_ops.ml
+++ b/src/opam_ops.ml
@@ -224,9 +224,6 @@ let distro_build ~packages ~target ~distro ~ocaml_version ~remotes ~typ ~opam_ve
   Docker_build.run docker_t.Docker_ops.build_t ~pull:true ~hum df >>= fun img ->
   build_packages docker_t img packages
 
-let primary_ocaml_version = "4.05.0"
-let compiler_variants = ["4.03.0";"4.04.2";"4.05.0";"4.06.0"]
-
 let run_phases ?volume ~revdeps ~packages ~remotes ~typ ~opam_version ~opam_repo opam_t docker_t target =
   let build distro ocaml_version =
     packages >>= function
@@ -234,7 +231,7 @@ let run_phases ?volume ~revdeps ~packages ~remotes ~typ ~opam_version ~opam_repo
     | packages -> distro_build ~packages ~target ~distro ~ocaml_version ~remotes ~typ ~opam_version ~opam_repo opam_t docker_t
   in
   (* phase 1 *)
-  let debian_stable = build "debian-9" primary_ocaml_version in
+  let debian_stable = build "debian-9" Oversions.primary in
   let phase1 = debian_stable >>= fun _ -> Term.return () in
   (* phase 2 revdeps *)
   let pkg_revdeps =
@@ -252,35 +249,35 @@ let run_phases ?volume ~revdeps ~packages ~remotes ~typ ~opam_version ~opam_repo
   let compiler_versions =
       List.map (fun oc ->
         let t = build "debian-9" oc in
-        ("OCaml "^oc), t
-      ) compiler_variants in
+        ("OCaml "^Oversions.to_string oc), t
+      ) Oversions.recents in
     let phase3 =
       Term_utils.after phase1 >>= fun () ->
       Term.wait_for_all compiler_versions in
     (* phase 4 *)
-    let alpine36 = build "alpine-3.6" primary_ocaml_version in
-    let ubuntu1604 = build "ubuntu-16.04" primary_ocaml_version in
-    let ubuntu1710 = build "ubuntu-17.10" primary_ocaml_version in
-    let centos7 = build "centos-7" primary_ocaml_version in
+    let alpine37 = build "alpine-3.7" Oversions.primary in
+    let ubuntu1604 = build "ubuntu-16.04" Oversions.primary in
+    let ubuntu1710 = build "ubuntu-17.10" Oversions.primary in
+    let centos7 = build "centos-7" Oversions.primary in
     let phase4 =
       Term_utils.after phase3 >>= fun () ->
       Term.wait_for_all [
-        "Alpine 3.6", alpine36;
+        "Alpine 3.7", alpine37;
         "Ubuntu 17.10", ubuntu1710;
         "Ubuntu 16.04", ubuntu1604;
-        "CentOS7", centos7 ] in
+        "CentOS 7", centos7 ] in
     (* phase 5 *)
-    let debiant = build "debian-testing" primary_ocaml_version in
-    let debianu = build "debian-unstable" primary_ocaml_version in
-    let _opensuse = build "opensuse-42.3" primary_ocaml_version in
-    let fedora26 = build "fedora-26" primary_ocaml_version in
+    let debiant = build "debian-testing" Oversions.primary in
+    let debianu = build "debian-unstable" Oversions.primary in
+    let opensuse = build "opensuse-42.3" Oversions.primary in
+    let fedora27 = build "fedora-27" Oversions.primary in
     let phase5 =
       Term_utils.after phase4 >>= fun () ->
       Term.wait_for_all [
         "Debian Testing", debiant;
         "Debian Unstable", debianu;
-(*        "OpenSUSE 42.2", opensuse; *)
-        "Fedora 26", fedora26 ]
+        "OpenSUSE 42.3", opensuse;
+        "Fedora 27", fedora27 ]
     in
     let lf = Fmt.strf "%s %s" (match opam_version with |`V1 -> "V1.2" |`V2 -> "V2.0") in
     [   Term_utils.report ~order:1 ~label:(lf "Build") phase1;

--- a/src/opam_ops.mli
+++ b/src/opam_ops.mli
@@ -13,7 +13,7 @@ val distro_build :
   packages:string list ->
   target:Datakit_ci.Target.t ->
   distro:string ->
-  ocaml_version:string ->
+  ocaml_version:Oversions.version ->
   remotes:(Datakit_github.Repo.t * string) list ->
   typ:[ `Package | `Repo | `Full_repo ] ->
   opam_version:[ `V1 | `V2 ] ->
@@ -63,4 +63,3 @@ module V2 : V
    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
   ---------------------------------------------------------------------------*)
-

--- a/src/oversions.ml
+++ b/src/oversions.ml
@@ -1,0 +1,17 @@
+type version = (string * string)
+
+let primary = ("4.05.0", "4.05")
+let recents = [("4.03.0","4.03");("4.04.2","4.04");primary;("4.06.0","4.06")]
+
+let to_string (_, v) = v
+
+let docker_opam1 (v, _) =
+  "ocaml-"^v
+
+let docker_opam2 v =
+  if v == primary then
+    "ocaml"
+  else
+    "ocaml-"^snd v
+
+let to_string_with_minor (v, _) = v

--- a/src/oversions.mli
+++ b/src/oversions.mli
@@ -1,0 +1,10 @@
+type version
+
+val primary : version
+val recents : version list
+
+val to_string : version -> string
+val docker_opam1 : version -> string
+val docker_opam2 : version -> string
+
+val to_string_with_minor : version -> string


### PR DESCRIPTION
This PR uses the new docker images from ocaml/opam2-staging (can be switched back to ocaml/opam2 if necessary) and also disables the broken opam1 images.