### PR TITLE
Disable ubuntu-17.10 + opam1

### DIFF
--- a/src/opam_ops.ml
+++ b/src/opam_ops.ml
@@ -266,9 +266,9 @@ let run_phases ?volume ~revdeps ~packages ~remotes ~typ ~opam_version ~opam_repo
     let phase4 =
       Term_utils.after phase3 >>= fun () ->
       wait_for_all_opam ~opam_version
-        [ "Ubuntu 17.10", ubuntu1710;
-          "Ubuntu 16.04", ubuntu1604 ]
+        [ "Ubuntu 16.04", ubuntu1604 ]
         [ "Alpine 3.7", alpine37;
+          "Ubuntu 17.10", ubuntu1710;
           "CentOS 7", centos7 ] in
     (* phase 5 *)
     let debiant = build "debian-testing" Oversions.primary in


### PR DESCRIPTION
ubuntu-17.10 doesn't exists (but 17.04 does) under the `ocaml/opam` docker hub.
I'm not sure how it worked before though, #25 didn't change that :/