### PR TITLE
Don't test for opam1 in the 2.0.0 branch on opam-repository

### DIFF
--- a/src/opam_ops.ml
+++ b/src/opam_ops.ml
@@ -232,11 +232,16 @@ let distro_build ~packages ~target ~distro ~ocaml_version ~remotes ~typ ~opam_ve
 let wait_for_all_opam ~opam_version v12 v2 =
   Term.wait_for_all (v12 @ match opam_version with `V1 -> [] | `V2 -> v2)
 
-let run_phases ?volume ~revdeps ~packages ~remotes ~typ ~opam_version ~opam_repo opam_t docker_t target =
+let run_phases ?volume ?(build_filter=Term.return true) ~revdeps ~packages ~remotes ~typ ~opam_version ~opam_repo opam_t docker_t target =
   let build distro ocaml_version =
-    packages >>= function
-    | [] -> Term.return []
-    | packages -> distro_build ~packages ~target ~distro ~ocaml_version ~remotes ~typ ~opam_version ~opam_repo opam_t docker_t
+    build_filter >>= function
+    | true ->
+        packages >>= begin function
+        | [] -> Term.return []
+        | packages -> distro_build ~packages ~target ~distro ~ocaml_version ~remotes ~typ ~opam_version ~opam_repo opam_t docker_t
+        end
+    | false ->
+        Term.return []
   in
   (* phase 1 *)
   let debian_stable = build "debian-9" Oversions.primary in

--- a/src/opam_ops.mli
+++ b/src/opam_ops.mli
@@ -23,6 +23,7 @@ val distro_build :
 
 val run_phases :
   ?volume: Fpath.t ->
+  ?build_filter:bool Datakit_ci.Term.t ->
   revdeps: bool ->
   packages:string list Datakit_ci.Term.t ->
   remotes:(Datakit_github.Repo.t * string) list ->


### PR DESCRIPTION
Currently PR specifically for opam2 are not treated differently from others and generate a lot of noises because tests using opam1 will all fail.

This PR tried to fix this but this needs to be tested first. I'll do that in the coming days.

Related to https://github.com/ocaml/opam-repository/pull/11968