### PR TITLE
Remove opam1.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   global:
   - PINS="mirage-ci:."
   matrix:
-  - PACKAGE="mirage-ci" OCAML_VERSION="4.03.0" DISTRO="debian-stable"
+  - PACKAGE="mirage-ci" OCAML_VERSION="4.03.0" DISTRO="debian-stable" EXTRA_ENV="OPAMSOLVERTIMEOUT=300"
   - PACKAGE="mirage-ci" OCAML_VERSION="4.04.2" DISTRO="ubuntu-16.04"
   - PACKAGE="mirage-ci" OCAML_VERSION="4.05.0" DISTRO="alpine"
   - PACKAGE="mirage-ci" OCAML_VERSION="4.06.0" DISTRO="alpine"

--- a/mirage-ci.opam
+++ b/mirage-ci.opam
@@ -1,19 +1,26 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "Anil Madhavapeddy <anil@recoil.org>"
-authors: ["Anil Madhavapeddy" "Thomas Gazagnaire" "Thomas Leonard" "Dave Tucker" ]
+authors: [
+  "Anil Madhavapeddy"
+  "Thomas Gazagnaire"
+  "Thomas Leonard"
+  "Dave Tucker"
+  "Kate <kit.ty.kate@disroot.org>"
+]
+synopsis: "Continuous Integration for MirageOS using DataKit's git workflow"
 homepage: "https://github.com/avsm/mirage-ci"
 doc: "http://docs.mirage.io/mirage-ci/"
 license: "ISC"
-dev-repo: "https://github.com/avsm/mirage-ci.git"
+dev-repo: "git://github.com/avsm/mirage-ci.git"
 bug-reports: "https://github.com/avsm/mirage-ci/issues"
-tags: [ "org:mirage" "org:ocamlabs"]
-available: [ ocaml-version >= "4.03.0"]
+tags: ["org:mirage" "org:ocamlabs"]
 depends: [
+  "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >="1.0+beta9"}
-  "ppx_sexp_conv" {build}
+  "ppx_sexp_conv"
   "dockerfile-cmd"
-  "datakit-ci" {>="0.12.0"}
-  "datakit-client" {>="0.11.0"}
+  "datakit-ci" {>= "0.12.0"}
+  "datakit-client" {>= "0.11.0"}
   "fpath"
   "asetmap"
   "bos"

--- a/src/opam_build.mli
+++ b/src/opam_build.mli
@@ -16,7 +16,7 @@ val v : logs:Live_log.manager -> label:string -> t
 
 val run : ?packages:string list -> ?target:Target.v -> distro:string ->
   ocaml_version:Oversions.version -> remotes:Opam_docker.Remote.t list -> typ:[`Package|`Repo|`Full_repo]
-  -> opam_version:[`V1|`V2] -> t -> Dockerfile.t Term.t
+  -> t -> Dockerfile.t Term.t
 (** [run t key] will result in a Datakit_ci {!Term.t} that will generate
   a {!Dockerfile.t} that can be built using a {!Docker_build.t} instance
   into a concrete image. *)

--- a/src/opam_docker.mli
+++ b/src/opam_docker.mli
@@ -20,7 +20,7 @@ val ocaml_opam_repository : Repo.t * string
 val mirage_opam_repository : Repo.t * string
 val js_opam_repository : Repo.t * string
 
-module type V = sig
+module Cmds : sig
   val add_cache_dir : Dockerfile.t
   val add_remotes : Remote.t list -> Dockerfile.t
   val set_opam_repo_rev : ?remote:Remote.t -> ?branch:string -> ?dst_branch:string -> string -> Dockerfile.t
@@ -33,9 +33,6 @@ module type V = sig
   val add_ci_script : Dockerfile.t
   val add_archive_script : Dockerfile.t
 end
-
-module V1 : V
-module V2 : V
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Anil Madhavapeddy

--- a/src/opam_ops.ml
+++ b/src/opam_ops.ml
@@ -10,89 +10,16 @@ open Datakit_github
 open Term.Infix
 module OD = Opam_docker
 
-module type V = sig
-  open Term
-  val build_archive : ?volume:Fpath.t -> Docker_ops.t -> string -> (Docker_build.image * string) t
-  val run_package : ?volume:Fpath.t -> Docker_run.t -> Docker_build.image -> string -> string t * string
-  val run_packages : ?volume:Fpath.t -> Docker_run.t -> Docker_build.image -> string list -> (string * string Datakit_ci.Term.t * string) list t
-  val list_all_packages : Docker_ops.t -> Docker_build.image -> string list t
-  val list_revdeps : Docker_ops.t -> Docker_build.image -> string -> string list t
-  val run_revdeps: ?volume:Fpath.t -> Docker_ops.t -> string -> Docker_build.image -> unit t
-end
-
 open Docker_ops
-module V1 = struct
-  open !Dockerfile
-
-  let build_archive ?volume {build_t;run_t;_} rev =
-    let dfile =
-      let open Dockerfile in
-      from ~tag:"alpine_ocaml-4.03.0" "ocaml/opam" @@
-      OD.V1.add_archive_script @@
-      OD.V1.set_opam_repo_rev rev in
-    let hum = Fmt.strf "base image for opam archive (%s)" (String.with_range ~len:6 rev) in
-    let volumes =
-      match volume with
-      | None -> []
-      | Some h -> [h,(Fpath.v "/home/opam/opam-repository/archives")]
-    in
-    Docker_build.run build_t ~pull:true ~hum dfile >>= fun img ->
-    let cmd = ["opam-ci-archive"] in
-    Docker_run.run ~volumes ~tag:img.Docker_build.sha256 ~cmd run_t >>= fun build ->
-    String.cuts ~sep:"\n" build |> List.rev |> function
-    | hd::_ -> Term.return (img, hd)
-    | [] -> Term.fail "No output from opam-admin make"
-
-  let list_all_packages {run_t;_} image =
-    let cmd = ["opam";"list";"-a";"-s";"--color=never"] in
-    Docker_run.run ~tag:image.Docker_build.sha256 ~cmd run_t >|=
-    String.cuts ~empty:false ~sep:"\n" >|=
-    List.map (fun s -> String.trim s)
-
-  let list_revdeps {run_t;_} image pkg =
-    let cmd = ["opam";"list";"-s";"--depends-on";pkg] in
-    Docker_run.run ~tag:image.Docker_build.sha256 ~cmd run_t >|=
-    String.cuts ~empty:false ~sep:"\n"
-
-  let run_package ?volume t image pkg =
-    let cmd = ["opam";"config";"exec";"--";"opam-ci-install";pkg] in
-    let hum = Fmt.strf "opam install %s" pkg in
-    let volumes =
-      match volume with
-      | None -> []
-      | Some h -> [h,(Fpath.v "/home/opam/opam-repository/archives")]
-    in
-    let r = Docker_run.run ~volumes ~tag:image.Docker_build.sha256 ~hum ~cmd t in
-    let b = Docker_run.branch ~volumes ~tag:image.Docker_build.sha256 ~cmd () in
-    r, b
-
-  let run_packages ?volume t image pkgs =
-    List.map (fun pkg ->
-      let t, branch = run_package ?volume t image pkg in
-      pkg, t, branch
-    ) pkgs |> fun r ->
-    Term.wait_for_all (List.map (fun (a,b,_) -> (a,b)) r) >>= fun () ->
-    Term.return r
-
-  let run_revdeps ?volume ({run_t;_} as t) pkg image =
-    let l = Fmt.strf "revdeps:%s" pkg in
-    let terms =
-      list_revdeps t image pkg >>=
-      run_packages ?volume run_t image
-    in
-    Term.wait_for_all [(l, terms)]
-
-end
-
-module V2 = struct
+module Cmds = struct
   open !Dockerfile
 
   let build_archive ?volume {build_t;run_t;_} rev =
     let dfile =
       from ~tag:"alpine_ocaml-4.03.0" "ocaml/opam-dev" @@
-      OD.V2.add_archive_script @@
-      OD.V2.set_opam_repo_rev rev @@
-      OD.V2.add_cache_dir
+      OD.Cmds.add_archive_script @@
+      OD.Cmds.set_opam_repo_rev rev @@
+      OD.Cmds.add_cache_dir
     in
     let hum = Fmt.strf "base image for opam2 archive (%s)" (String.with_range ~len:6 rev) in
     let volumes =
@@ -151,7 +78,7 @@ module V2 = struct
 
 end
 
-let build_package ~opam_version {build_t;_} image pkg =
+let build_package {build_t;_} image pkg =
   let base_pkg, version_pkg = match String.cut ~sep:"." pkg with
     | None -> failwith ("Couldn't extract the version number from "^pkg)
     | Some x -> x
@@ -159,18 +86,14 @@ let build_package ~opam_version {build_t;_} image pkg =
   let open !Dockerfile in
   let dfile =
     from image.Docker_build.sha256 @@
-    begin match opam_version with
-    | `V1 -> empty (* opam1 pin fails when the package doesn't have any archive
-                      to download. (for instance with meta packages) *)
-    | `V2 -> run "opam pin add -k version -yn %s %s" base_pkg version_pkg
-    end @@
+    run "opam pin add -k version -yn %s %s" base_pkg version_pkg @@
     run "opam config exec -- opam-ci-install %s" pkg in
   let hum = Fmt.strf "opam install %s" pkg in
   Docker_build.run build_t ~hum dfile
 
-let build_packages ~opam_version t image pkgs =
+let build_packages t image pkgs =
   let builds = List.map (fun pkg ->
-    let t = build_package ~opam_version t image pkg in
+    let t = build_package t image pkg in
     pkg, t
   ) pkgs in
   Term.wait_for_all builds >>= fun () ->
@@ -206,12 +129,7 @@ let packages_from_diff ?(default=["ocamlfind"]) {build_t;run_t;_} target =
     Docker_run.run ~tag:img.Docker_build.sha256 ~cmd run_t >|=
     fun x -> String.cuts ~empty:false ~sep:"\n" x |> List.map String.trim
 
-let run_revdeps ?volume ~opam_version docker_t pkg img =
-  match opam_version with
-  |`V1 -> V1.run_revdeps ?volume docker_t pkg img
-  |`V2 -> V2.run_revdeps ?volume docker_t pkg img
-
-let distro_build ~packages ~target ~distro ~ocaml_version ~remotes ~typ ~opam_version ~opam_repo opam_t docker_t =
+let distro_build ~packages ~target ~distro ~ocaml_version ~remotes ~typ ~opam_repo opam_t docker_t =
   (* Get the commits for the mainline opam repo *)
   let opam_repo, opam_repo_branch = opam_repo in
   Term.branch_head opam_repo opam_repo_branch >>= fun opam_repo_commit ->
@@ -223,36 +141,31 @@ let distro_build ~packages ~target ~distro ~ocaml_version ~remotes ~typ ~opam_ve
   ) remotes >>= fun remotes ->
   let remotes = opam_repo_remote :: remotes in
   Term.target target >>= fun target ->
-  Opam_build.run ~packages ~target ~distro ~ocaml_version ~remotes ~typ ~opam_version opam_t >>= fun df ->
+  Opam_build.run ~packages ~target ~distro ~ocaml_version ~remotes ~typ opam_t >>= fun df ->
   let hum = Fmt.(strf "base image for opam install %a" (list ~sep:sp string) packages) in
   Docker_build.run docker_t.Docker_ops.build_t ~pull:true ~hum df >>= fun img ->
-  build_packages ~opam_version docker_t img packages
+  build_packages docker_t img packages
 
-(* NOTE: Function used to temporarily disable brocken opam1 images *)
-let wait_for_all_opam ~opam_version v12 v2 =
-  Term.wait_for_all (v12 @ match opam_version with `V1 -> [] | `V2 -> v2)
-
-let run_phases ?volume ?(build_filter=Term.return true) ~revdeps ~packages ~remotes ~typ ~opam_version ~opam_repo opam_t docker_t target =
+let run_phases ?volume ?(build_filter=Term.return true) ~revdeps ~packages ~remotes ~typ ~opam_repo opam_t docker_t target =
   let build distro ocaml_version =
     build_filter >>= function
     | true ->
-        packages >>= begin function
-        | _::_ as packages -> distro_build ~packages ~target ~distro ~ocaml_version ~remotes ~typ ~opam_version ~opam_repo opam_t docker_t
+        packages >>= begin fun packages -> match packages with
+        | _::_ -> distro_build ~packages ~target ~distro ~ocaml_version ~remotes ~typ ~opam_repo opam_t docker_t
         | [] -> Term.return []
         end
     | false ->
         Term.return []
   in
   (* phase 1 *)
-  let primary_version = Oversions.primary ~opam_version in
+  let primary_version = Oversions.primary in
   let debian_stable = build "debian-9" primary_version in
   let phase1 = debian_stable >>= fun _ -> Term.return () in
   (* phase 2 revdeps *)
   let pkg_revdeps =
     debian_stable >>= fun debian_stable ->
     let ts = List.map (fun (l,img) ->
-      let t =
-        run_revdeps ?volume ~opam_version docker_t l img in
+      let t = Cmds.run_revdeps ?volume docker_t l img in
       (Fmt.strf "revdep:%s" l), t
     ) debian_stable in
     Term.wait_for_all ts in
@@ -264,7 +177,7 @@ let run_phases ?volume ?(build_filter=Term.return true) ~revdeps ~packages ~remo
       List.map (fun oc ->
         let t = build "debian-9" oc in
         ("OCaml "^Oversions.to_string oc), t
-      ) (Oversions.recents ~opam_version) in
+      ) Oversions.recents in
     let phase3 =
       Term_utils.after phase1 >>= fun () ->
       Term.wait_for_all compiler_versions in
@@ -275,9 +188,9 @@ let run_phases ?volume ?(build_filter=Term.return true) ~revdeps ~packages ~remo
     let centos = build "centos" primary_version in
     let phase4 =
       Term_utils.after phase3 >>= fun () ->
-      wait_for_all_opam ~opam_version
-        [ "Ubuntu 16.04", ubuntu1604 ]
-        [ "Alpine", alpine;
+      Term.wait_for_all
+        [ "Ubuntu 16.04", ubuntu1604;
+          "Alpine", alpine;
           "Ubuntu LTS", ubuntu_lts;
           "CentOS", centos ] in
     (* phase 5 *)
@@ -287,19 +200,18 @@ let run_phases ?volume ?(build_filter=Term.return true) ~revdeps ~packages ~remo
     let fedora = build "fedora" primary_version in
     let phase5 =
       Term_utils.after phase4 >>= fun () ->
-      wait_for_all_opam ~opam_version
+      Term.wait_for_all
         [ "Debian Testing", debiant;
-          "Debian Unstable", debianu ]
-        [ "Fedora", fedora;
+          "Debian Unstable", debianu;
+          "Fedora", fedora;
           "OpenSUSE", opensuse ]
     in
-    let lf = Fmt.strf "%s %s" (match opam_version with |`V1 -> "V1.2" |`V2 -> "V2.0") in
-    [   Term_utils.report ~order:1 ~label:(lf "Build") phase1;
-        Term_utils.report ~order:3 ~label:(lf "Compilers") phase3;
-        Term_utils.report ~order:4 ~label:(lf "Common Distros") phase4;
-        Term_utils.report ~order:5 ~label:(lf "All Distros") phase5;
+    [   Term_utils.report ~order:1 ~label:"Build" phase1;
+        Term_utils.report ~order:3 ~label:"Compilers" phase3;
+        Term_utils.report ~order:4 ~label:"Common Distros" phase4;
+        Term_utils.report ~order:5 ~label:"All Distros" phase5;
     ] @ (match revdeps with false -> [] | true ->
-        [Term_utils.report ~order:2 ~label:(lf "Revdeps") phase2])
+        [Term_utils.report ~order:2 ~label:"Revdeps" phase2])
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Anil Madhavapeddy

--- a/src/opam_ops.mli
+++ b/src/opam_ops.mli
@@ -16,7 +16,6 @@ val distro_build :
   ocaml_version:Oversions.version ->
   remotes:(Datakit_github.Repo.t * string) list ->
   typ:[ `Package | `Repo | `Full_repo ] ->
-  opam_version:[ `V1 | `V2 ] ->
   opam_repo:Datakit_github.Repo.t * string ->
   Opam_build.t ->
   Docker_ops.t -> (string * Docker_build.image) list Datakit_ci.Term.t
@@ -28,16 +27,12 @@ val run_phases :
   packages:string list Datakit_ci.Term.t ->
   remotes:(Datakit_github.Repo.t * string) list ->
   typ:[ `Package | `Repo | `Full_repo ] ->
-  opam_version:[ `V1 | `V2 ] ->
   opam_repo:Datakit_github.Repo.t * string ->
   Opam_build.t ->
   Docker_ops.t ->
   Datakit_ci.Target.t -> (string * string Datakit_ci.Term.t) list
 
-val run_revdeps : ?volume:Fpath.t -> opam_version:[`V1|`V2] ->
-  Docker_ops.t -> string -> Docker_build.image -> unit t
-
-module type V = sig
+module Cmds : sig
   val build_archive : ?volume:Fpath.t -> Docker_ops.t -> string -> (Docker_build.image * string) t
   val run_package : ?volume:Fpath.t -> Docker_run.t -> Docker_build.image -> string -> string t * string
   val run_packages : ?volume:Fpath.t -> Docker_run.t -> Docker_build.image -> string list -> (string * string Datakit_ci.Term.t * string) list t
@@ -45,9 +40,6 @@ module type V = sig
   val list_revdeps : Docker_ops.t -> Docker_build.image -> string -> string list t
   val run_revdeps: ?volume:Fpath.t -> Docker_ops.t -> string -> Docker_build.image -> unit t
 end
-
-module V1 : V
-module V2 : V
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Anil Madhavapeddy

--- a/src/oversions.ml
+++ b/src/oversions.ml
@@ -1,29 +1,18 @@
 type version = string
 
 let latest = "4.07"
-
-let primary ~opam_version = match opam_version with
-| `V1 -> "4.05.0"
-| `V2 -> latest
-
-let recents ~opam_version = match opam_version with
-| `V1 -> [
-    "4.03.0";
-    "4.04.2";
-    "4.05.0";
-    "4.06.0";
-  ]
-| `V2 -> [
-    "4.03";
-    "4.04";
-    "4.05";
-    "4.06";
-    "4.07";
-  ]
+let primary = latest
+let recents = [
+  "4.03";
+  "4.04";
+  "4.05";
+  "4.06";
+  "4.07";
+]
 
 let to_string v = v
 
-let docker ~opam_version v = match opam_version with
-| `V1 -> "_ocaml-"^v
-| `V2 when v == latest -> ""
-| `V2 -> "-ocaml-"^v
+let docker v =
+  if v == latest
+  then ""
+  else "-ocaml-"^v

--- a/src/oversions.mli
+++ b/src/oversions.mli
@@ -1,7 +1,7 @@
 type version
 
-val primary : opam_version:[`V1 | `V2] -> version
-val recents : opam_version:[`V1 | `V2] -> version list
+val primary : version
+val recents : version list
 
 val to_string : version -> string
-val docker : opam_version:[`V1 | `V2] -> version -> string
+val docker : version -> string


### PR DESCRIPTION
opam 1.2 is not actively supported and Travis can handle alone PRs on the `1.2` branch.
This PR basically removes a lot of code and also now only make the CI tests only the `master` branch.

Side note: any PRs to others branches are going to display empty&successful logs due to the way datakit handles github tasks (i.e. we can't get the target branch outside the `Term.t` monad and all github tasks are decided statically outside this monad)