### PR TITLE
Add ci.ocaml.org deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,23 @@ git-jar make -s repo $USER datakit-github-cookie
 Replace $USER with your GitHub user name.
 Note: `repo` indicates the token's scope, not a repository name.
 
-Move the resulting `~/.github/jar/datakit-github-cookie` file to `mirage-ci/data/bridge/datakit-github-cookie`.
-Note: this file MUST NOT have any "other" permissions set in its Unix permissions.
-Otherwise, the bridge will refuse to start, saying that the file doesn't exist.
+- For docker-compose:
+  Move the resulting `~/.github/jar/datakit-github-cookie` file to `mirage-ci/data/bridge/datakit-github-cookie`.
+  Note: this file MUST NOT have any "other" permissions set in its Unix permissions.
+  Otherwise, the bridge will refuse to start, saying that the file doesn't exist.
+
+- For docker-stack:
+  `docker secret create datakit-github-cookie-bactrian - < ~/.github/jar/datakit-github-cookie`
 
 For local testing, you might also want to put the bridge into read-only mode, by changing its `-c` option to `-c "*:r"` in `docker-compose.yml`.
 
-To build and run `opam-repo-ci` locally (for testing):
+To build and run `opam-repo-ci` locally (for testing) with docker-compose:
 
 ```
 env CI_BINARY=opam-repo-ci CI_DOMAIN_NAME=localhost docker-compose up
 ```
+
+For production use, use Docker stack: `docker stack deploy opam-repo-ci -c opam-repo-ci.yml`
 
 You should see a message like this in the logs:
 

--- a/opam-repo-ci.yml
+++ b/opam-repo-ci.yml
@@ -1,0 +1,61 @@
+version: '3.1'
+volumes:
+  session_data:
+  datakit-data:
+  ci-secrets:
+  ci-cache:
+  prometheus-data:
+  prometheus-config:
+  grafana-storage:
+secrets:
+  datakit-github-cookie-bactrian:
+    external: true
+services:
+  ci:
+    image: opam-repo-ci
+    entrypoint: /home/opam/.opam/4.07/bin/opam-repo-ci
+    command: --listen-prometheus=9090 --metadata-store tcp:datakit:5640 --web-ui=https://ci.ocaml.org/ --sessions-backend=redis://redis
+    ports:
+     - "443:8443"
+    volumes:
+      - 'ci-cache:/data/repos'
+      - 'ci-secrets:/secrets'
+      - '/var/run/docker.sock:/var/run/docker.sock'
+    depends_on:
+     - datakit
+     - redis
+  datakit:
+    image: datakit/db
+    user: "root"
+    volumes:
+      - datakit-data:/data
+    command: --git /data --listen-prometheus=9090 --listen-9p tcp://0.0.0.0:5640
+  bridge:
+    image: datakit/github-bridge:0.11.0
+    command: --listen-prometheus=9090 --datakit tcp://datakit:5640 -v -c "*:r,status[ci/datakit]:x,webhook:rw" --webhook http://ci.ocaml.org:8100
+    ports:
+     - "8100:8100"
+    secrets:
+      - source: 'datakit-github-cookie-bactrian'
+        target: 'datakit-github-cookie'
+        mode: 0600
+    depends_on:
+     - datakit
+  redis:
+    image: redis
+    command: redis-server --save 60 1
+    volumes:
+      - session_data:/data
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - "prometheus-data:/prometheus"
+      - "prometheus-config:/etc/prometheus:ro"
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - "grafana-storage:/var/lib/grafana"
+    environment:
+      - "GF_SERVER_ROOT_URL=http://ci.ocaml.org"


### PR DESCRIPTION
This is based on the compose file, but uses Docker stack. This should be more reliable because Docker itself will restart the services on failure, or on reboot of the server. It also makes it easier to update individual services.

The new configuration adds monitoring with Prometheus and Grafana, uses named volumes instead of local directories, and uses Docker secrets for the GitHub token.