### PR TITLE
Don't ask for any scopes for GitHub auth

### DIFF
--- a/src-bin/opamRepoCI.ml
+++ b/src-bin/opamRepoCI.ml
@@ -55,6 +55,7 @@ let web_config =
     ~name:"opam-repo-ci"
     ~can_read:ACL.(everyone)
     ~can_build:ACL.(everyone)
+    ~github_scopes_needed:[]
     ~state_repo:(Uri.of_string "https://github.com/ocaml/ocaml-ci.logs")
     ()
 


### PR DESCRIPTION
opam-repository is public, so we don't need access to private repositories too.

Reported by Daniel Bünzli in https://github.com/avsm/mirage-ci/issues/8