### PR TITLE
Some improvements for local testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 data
+_build
 _checkouts
 .git

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM ocaml/opam2:alpine
 RUN sudo apk add --update docker
 RUN cd /home/opam/opam-repository && git pull origin master && opam update -uy
 RUN opam depext -uivy irmin-unix ezjsonm bos ptime fmt datakit-ci conf-libev 
-ADD . /home/opam/src
-RUN sudo chown -R opam /home/opam/src
+ADD --chown=1000 mirage-ci.opam /home/opam/src/
+RUN opam install --deps-only /home/opam/src/
+ADD --chown=1000 . /home/opam/src
 RUN opam pin add -n mirage-ci /home/opam/src
 RUN opam install -vy mirage-ci
 ENV CONDUIT_TLS=native

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     restart: always
     build: .
     entrypoint: /home/opam/.opam/4.07/bin/${CI_BINARY}
-    command: --metadata-store tcp:datakit:5640 --web-ui=https://${CI_DOMAIN_NAME}/ --sessions-backend=redis://redis
+    command: --metadata-store tcp:datakit:5640 --web-ui=https://${CI_DOMAIN_NAME}/ --sessions-backend=redis://redis # --canary=ocaml/opam-repository/prs/14252
     ports:
      - "443:8443"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
   bridge:
     restart: always
     image: datakit/github-bridge:0.11.0
-    command: --datakit tcp://datakit:5640 -v -c "*:r,status[ci/datakit]:x,webhook:rw" --webhook http://${CI_DOMAIN_NAME}:8100
+    command: --datakit tcp://datakit:5640 -v -c "*:r" --webhook http://${CI_DOMAIN_NAME}:8100
     ports:
      - "8100:8100"
     volumes:


### PR DESCRIPTION
- Speed up rebuilds of the Docker image by adding the `opam` file first to get the deps.
- Configure the docker-compose bridge in read-only mode to avoid accidental pushes.
- Add a canary example to docker-compose, as you probably want to test on just one PR locally.
- Exclude `_build` from docker build.