### PR TITLE
Increase OPAMSOLVERTIMEOUT

### DIFF
--- a/src/opam_ops.ml
+++ b/src/opam_ops.ml
@@ -94,6 +94,7 @@ let build_package ?(with_tests=false) {build_t;_} image pkg =
     from image.Docker_build.sha256 @@
     run "opam pin add -k version -yn %s %s" base_pkg version_pkg @@
     tests_env @@
+    env ["OPAMSOLVERTIMEOUT","500"] @@
     run "opam exec -- opam-ci-install %s" pkg in
   let hum =
     match with_tests with


### PR DESCRIPTION
I don't know why opam needs a solver timeout in the first place, but having CI jobs fail because of it certainly doesn't seem useful.

See: https://github.com/ocaml/opam-repository/pull/14252#issuecomment-500116966