### PR TITLE
Add OCaml 4.08 to the test array and use it as primary image

### DIFF
--- a/src/oversions.ml
+++ b/src/oversions.ml
@@ -1,6 +1,6 @@
 type version = string
 
-let latest = "4.07"
+let latest = "4.08"
 let primary = latest
 let recents = [
   "4.03";
@@ -8,6 +8,7 @@ let recents = [
   "4.05";
   "4.06";
   "4.07";
+  "4.08";
 ]
 
 let to_string v = v


### PR DESCRIPTION
This adds support for OCaml 4.08 recently released in https://github.com/ocaml/opam-repository/pull/14282