### PR TITLE
Use ocaml-version and only use the default docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ RUN opam depext -uivy irmin-unix ezjsonm bos ptime fmt datakit-ci conf-libev
 ADD --chown=1000 mirage-ci.opam /home/opam/src/
 RUN opam install --deps-only /home/opam/src/
 ADD --chown=1000 . /home/opam/src
-RUN opam pin add -n mirage-ci /home/opam/src
-RUN opam install -vy mirage-ci
+RUN opam pin add -n mirage-ci.dev /home/opam/src
+RUN opam pin add -n ocaml-version.dev git://github.com/avsm/ocaml-version.git
+RUN opam install -vy ocaml-version.dev mirage-ci.dev
 ENV CONDUIT_TLS=native
 ENV OCAMLRUNPARAM=b
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ocaml/opam2:alpine
 RUN sudo apk add --update docker
 RUN cd /home/opam/opam-repository && git pull origin master && opam update -uy
+RUN opam switch 4.07
 RUN opam depext -uivy irmin-unix ezjsonm bos ptime fmt datakit-ci conf-libev 
 ADD --chown=1000 mirage-ci.opam /home/opam/src/
 RUN opam install --deps-only /home/opam/src/

--- a/src/opam_docker.ml
+++ b/src/opam_docker.ml
@@ -91,8 +91,9 @@ module Cmds = struct
     run "opam pin add -y opam-ci-scripts https://github.com/kit-ty-kate/opam-ci-scripts.git"
 
   let base ~ocaml_version ~distro =
-    from ~tag:(distro^Oversions.docker ocaml_version) "ocaml/opam2" @@
+    from ~tag:distro "ocaml/opam2" @@
     add_cache_dir @@
+    run "opam switch %s" (Oversions.to_string ocaml_version) @@
     run "opam install -yv opam-depext"
 
   let add_archive_script =

--- a/src/oversions.ml
+++ b/src/oversions.ml
@@ -1,19 +1,7 @@
-type version = string
+type version = Ocaml_version.t
 
-let default = "default" (* default OCaml version in the default docker images *)
-let primary = default
-let recents = [
-  "4.03";
-  "4.04";
-  "4.05";
-  "4.06";
-  "4.07";
-  "4.08";
-]
+let primary = Ocaml_version.Releases.latest
+let recents = Ocaml_version.Releases.recent
 
-let to_string v = v
-
-let docker v =
-  if v == default
-  then ""
-  else "-ocaml-"^v
+let to_string v =
+  Ocaml_version.to_string (Ocaml_version.with_just_major_and_minor v)

--- a/src/oversions.mli
+++ b/src/oversions.mli
@@ -4,4 +4,3 @@ val primary : version
 val recents : version list
 
 val to_string : version -> string
-val docker : version -> string


### PR DESCRIPTION
This PR make use of https://github.com/avsm/ocaml-version and only use the default docker image instead of loading the images containing specifically the compiler version wanted.

This PR shouldn't change anything except that we'll now test for OCaml 4.02 as well (https://github.com/avsm/ocaml-version/blob/ba8b4fa6a155004475b9f79915710e58433d1d49/ocaml_version.ml#L125)

Also the deployment changes somewhat as we should notice that installation becomes sensible to the version of `ocaml-version`. To counter that I added a pin to the development version of `ocaml-version` in the Dockerfile.