### PR TITLE
Do not wait for previous phases to be successful to start phases 3, 4 and 5

### DIFF
--- a/src/opam_ops.ml
+++ b/src/opam_ops.ml
@@ -190,16 +190,13 @@ let run_phases ?volume ?(build_filter=Term.return true) ~revdeps ~packages ~remo
         let t = build ~with_tests:true "debian-stable" oc in
         ("OCaml "^Oversions.to_string oc), t
       ) Oversions.recents in
-    let phase3 =
-      Term_utils.after phase1 >>= fun () ->
-      Term.wait_for_all compiler_versions in
+    let phase3 = Term.wait_for_all compiler_versions in
     (* phase 4 *)
     let alpine = build ~with_tests:true "alpine" primary_version in
     let ubuntu1604 = build ~with_tests:false "ubuntu-16.04" primary_version in
     let ubuntu_lts = build ~with_tests:false "ubuntu-lts" primary_version in
     let centos = build ~with_tests:false "centos" primary_version in
     let phase4 =
-      Term_utils.after phase3 >>= fun () ->
       Term.wait_for_all
         [ "Ubuntu 16.04", ubuntu1604;
           "Alpine", alpine;
@@ -211,7 +208,6 @@ let run_phases ?volume ?(build_filter=Term.return true) ~revdeps ~packages ~remo
     let opensuse = build ~with_tests:false "opensuse" primary_version in
     let fedora = build ~with_tests:false "fedora" primary_version in
     let phase5 =
-      Term_utils.after phase4 >>= fun () ->
       Term.wait_for_all
         [ "Debian Testing", debiant;
           "Debian Unstable", debianu;

--- a/src/opam_ops.mli
+++ b/src/opam_ops.mli
@@ -9,18 +9,6 @@ open Datakit_ci.Term
 
 val packages_from_diff : ?default:string list -> Docker_ops.t -> Datakit_ci.Target.t -> string list t
 
-val distro_build :
-  packages:string list ->
-  target:Datakit_ci.Target.t ->
-  distro:string ->
-  ocaml_version:Oversions.version ->
-  remotes:(Datakit_github.Repo.t * string) list ->
-  typ:[ `Package | `Repo | `Full_repo ] ->
-  opam_repo:Datakit_github.Repo.t * string ->
-  with_tests:bool ->
-  Opam_build.t ->
-  Docker_ops.t -> (string * Docker_build.image) list Datakit_ci.Term.t
-
 val run_phases :
   ?volume: Fpath.t ->
   ?build_filter:bool Datakit_ci.Term.t ->


### PR DESCRIPTION
Some packages can't work with Debian stable and require some other distribution instead. This would allow the opam-repository maintainers to see that more clearly. Moreover it might also be useful for people to see which version of the compiler works if the latest one doesn't, sometimes it has to do with dependencies and having packages fail in different ways might help people understand why their packages fail.