### PR TITLE
Install ocaml-secondary-compiler when testing on OCaml < 4.07 to speed up packages using dune

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 env:
   global:
   - PACKAGE="mirage-ci"
-  - EXTRA_ENV="OPAMSOLVERTIMEOUT=600"
+  - EXTRA_ENV="OPAMSOLVERTIMEOUT=6000"
   matrix:
   - OCAML_VERSION="4.06" DISTRO="alpine"
   - OCAML_VERSION="4.07" DISTRO="alpine"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
-script: bash -ex .travis-docker.sh
+script: travis_wait 30 bash -ex .travis-docker.sh
 services:
 - docker
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
-script: travis_wait 30 bash -ex .travis-docker.sh
+script: travis_wait 50 bash -ex .travis-docker.sh
 services:
 - docker
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 env:
   global:
   - PACKAGE="mirage-ci"
+  - EXTRA_ENV="OPAMSOLVERTIMEOUT=600"
   matrix:
   - OCAML_VERSION="4.06" DISTRO="alpine"
   - OCAML_VERSION="4.07" DISTRO="alpine"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ocaml/opam2:alpine
 RUN sudo apk add --update docker
 RUN cd /home/opam/opam-repository && git pull origin master && opam update -uy
 RUN opam switch 4.07
+ENV OPAMSOLVERTIMEOUT=600
 RUN opam depext -uivy irmin-unix ezjsonm bos ptime fmt datakit-ci conf-libev 
 ADD --chown=1000 mirage-ci.opam /home/opam/src/
 RUN opam install --deps-only /home/opam/src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ocaml/opam2:alpine
 RUN sudo apk add --update docker
 RUN cd /home/opam/opam-repository && git pull origin master && opam update -uy
 RUN opam switch 4.07
-ENV OPAMSOLVERTIMEOUT=600
+ENV OPAMSOLVERTIMEOUT=6000
 RUN opam depext -uivy irmin-unix ezjsonm bos ptime fmt datakit-ci conf-libev 
 ADD --chown=1000 mirage-ci.opam /home/opam/src/
 RUN opam install --deps-only /home/opam/src/

--- a/src/opam_docker.ml
+++ b/src/opam_docker.ml
@@ -94,7 +94,13 @@ module Cmds = struct
     from ~tag:distro "ocaml/opam2" @@
     add_cache_dir @@
     run "opam switch %s" (Oversions.to_string ocaml_version) @@
-    run "opam install -yv opam-depext"
+    run "opam install -yv opam-depext%s"
+      (if Oversions.older_than_4_06 ocaml_version
+       then " ocaml-secondary-compiler" (* NOTE: This is needed since dune 2.0.0
+                                           requires at least OCaml 4.06 OR this package
+                                           to build, which takes more than 4 minutes
+                                           to compile *)
+       else "")
 
   let add_archive_script =
     generate_sh "opam-ci-archive" [

--- a/src/opam_docker.ml
+++ b/src/opam_docker.ml
@@ -97,9 +97,9 @@ module Cmds = struct
     run "git pull origin master" @@
     run "opam update" @@
     run "opam install -yv opam-depext%s"
-      (if Oversions.older_than_4_06 ocaml_version
-       then " ocaml-secondary-compiler" (* NOTE: This is needed since dune 2.0.0
-                                           requires at least OCaml 4.06 OR this package
+      (if Oversions.older_than_4_07 ocaml_version
+       then " ocaml-secondary-compiler" (* NOTE: This is needed since dune 2.1.0
+                                           requires at least OCaml 4.07 OR this package
                                            to build, which takes more than 4 minutes
                                            to compile *)
        else "")

--- a/src/opam_docker.ml
+++ b/src/opam_docker.ml
@@ -94,6 +94,8 @@ module Cmds = struct
     from ~tag:distro "ocaml/opam2" @@
     add_cache_dir @@
     run "opam switch %s" (Oversions.to_string ocaml_version) @@
+    run "git pull origin master" @@
+    run "opam update" @@
     run "opam install -yv opam-depext%s"
       (if Oversions.older_than_4_06 ocaml_version
        then " ocaml-secondary-compiler" (* NOTE: This is needed since dune 2.0.0

--- a/src/oversions.ml
+++ b/src/oversions.ml
@@ -3,5 +3,8 @@ type version = Ocaml_version.t
 let primary = Ocaml_version.Releases.latest
 let recents = Ocaml_version.Releases.recent
 
+let older_than_4_06 v =
+  Ocaml_version.compare v Ocaml_version.Releases.v4_06_0 < 0
+
 let to_string v =
   Ocaml_version.to_string (Ocaml_version.with_just_major_and_minor v)

--- a/src/oversions.ml
+++ b/src/oversions.ml
@@ -3,8 +3,8 @@ type version = Ocaml_version.t
 let primary = Ocaml_version.Releases.latest
 let recents = Ocaml_version.Releases.recent
 
-let older_than_4_06 v =
-  Ocaml_version.compare v Ocaml_version.Releases.v4_06_0 < 0
+let older_than_4_07 v =
+  Ocaml_version.compare v Ocaml_version.Releases.v4_07_0 < 0
 
 let to_string v =
   Ocaml_version.to_string (Ocaml_version.with_just_major_and_minor v)

--- a/src/oversions.mli
+++ b/src/oversions.mli
@@ -3,4 +3,6 @@ type version
 val primary : version
 val recents : version list
 
+val older_than_4_06 : version -> bool
+
 val to_string : version -> string

--- a/src/oversions.mli
+++ b/src/oversions.mli
@@ -3,6 +3,6 @@ type version
 val primary : version
 val recents : version list
 
-val older_than_4_06 : version -> bool
+val older_than_4_07 : version -> bool
 
 val to_string : version -> string


### PR DESCRIPTION
https://github.com/ocaml/opam-repository/pull/15404 introduces `ocamlfind-secondary` as dependency of dune and adds up a significant time to build this package everytime a package needs to be tested on OCaml < 4.06