### PR TITLE
Avoid the CI from crashing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     command: --git /data --listen-9p tcp://0.0.0.0:5640
   bridge:
     restart: always
-    image: datakit/github-bridge:0.11.0
+    image: datakit/github-bridge
     command: --datakit tcp://datakit:5640 -v -c "*:r" --webhook http://${CI_DOMAIN_NAME}:8100
     ports:
      - "8100:8100"

--- a/mirage-ci.opam
+++ b/mirage-ci.opam
@@ -16,8 +16,8 @@ bug-reports: "https://github.com/avsm/mirage-ci/issues"
 tags: ["org:mirage" "org:ocamlabs"]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
-  "ppx_sexp_conv" {>="v0.9.0"}
+  "dune" {>= "1.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "dockerfile-cmd"
   "datakit-ci" {>= "0.12.0"}
   "datakit-client" {>= "0.11.0"}

--- a/opam-repo-ci.yml
+++ b/opam-repo-ci.yml
@@ -31,7 +31,7 @@ services:
       - datakit-data:/data
     command: --git /data --listen-prometheus=9090 --listen-9p tcp://0.0.0.0:5640
   bridge:
-    image: datakit/github-bridge:0.11.0
+    image: datakit/github-bridge
     command: --listen-prometheus=9090 --datakit tcp://datakit:5640 -v -c "*:r,status[ci/datakit]:x,webhook:rw" --webhook http://ci.ocaml.org:8100
     ports:
      - "8100:8100"

--- a/src-bin/opamRepoCI.ml
+++ b/src-bin/opamRepoCI.ml
@@ -10,6 +10,9 @@ open Datakit_ci
 open Term.Infix
 module DO = Docker_ops
 
+let () = Lwt.async_exception_hook := (fun exc ->
+  prerr_endline ("[Error caught in the Lwt.async_exception_hook]: "^Printexc.to_string exc))
+
 module Builder = struct
 
   let label = "opamRepo"


### PR DESCRIPTION
Conduit 2.0.0 / Cohttp 2.2.0 fix an issue that makes a cohttp server crash if no exception handler has been defined.
However mirage-ci uses datakit-ci, which is not compatible with this version of conduit yet.

As a temporary fix, we define the Lwt exception handler in mirage-ci. This should take care of the issue.
I'm not entirely sure why we didn't get more of that failure sooner but at least this way it is fixed anyway.

More details in https://github.com/mirage/ocaml-conduit/pull/261 and https://github.com/mirage/ocaml-cohttp/pull/669